### PR TITLE
Merge pull request #31 from joshkel/fix-jvvalidateedit-validation

### DIFF
--- a/jvcl/run/JvgDrawTab.pas
+++ b/jvcl/run/JvgDrawTab.pas
@@ -368,7 +368,7 @@ begin
             fhaCenter:
               X := R1.Left + (R1.Right - R1.Left + Size.cx) div 2;
             fhaRight:
-              Y := R1.Left + Size.cx;
+              X := R1.Left + Size.cx;
           end;
           case CaptionVAlign of
             fvaTop:


### PR DESCRIPTION
Mantis 6424: TJvValidateEdit only enforces min/max if losing focus